### PR TITLE
Made everything more general

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ansible-galaxy collection install community.general
 ansible-galaxy collection install community.postgresql
 ```
 
-Once you have the prerequisites, from the root of this repo you can build and run the container
+Once you have the prerequisites, from the root of this repo you can build and run the container. The name should match the ansible inventory list in the inventory.containers file.
 
 ```
 podman build -t bootc-django-t1 bootc/
@@ -61,6 +61,7 @@ sudo podman run --rm -it --privileged --pull=newer --network=host --security-opt
 Get the QCOW image from the output/qcow directory and import into a KVM environment to test.
 
 **VM Issues**
+There are a few 'localhost' hardcoded spots that are workarounds for the current playbooks but probably would raise issues in a production setting
 
 The services are not enabled on boot in the QCOW image
 Seboolean needs to be set after first boot to allow communication over the unix socket

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Use ansible to create a Django 5 environment on top of a bootc based OS with the
 
 The bootc container only contains the OS level mods required for this Django layer to become a functional app environment once configured at run time
 
-** note: the separation of the playbooks is ongoing **
+**note: the separation of the playbooks is ongoing**
 
 The first set of ansible playbooks contains 'generic' customizations that wire up the django environment according to local standards in prepartion for landing the application later
 
@@ -16,32 +16,33 @@ On the **build host** you'll need the following packages:
 * ansible
 * general, podman, and postgresql ansible collections
 
-'''
+
+```
 sudo dnf install -y podman ansible
 
 ansible-galaxy collection install containers.podman
 ansible-galaxy collection install community.general
 ansible-galaxy collection install community.postgresql
-'''
+```
 
 Once you have the prerequisites, from the root of this repo you can build and run the container
 
-'''
+```
 podman build -t bootc-django-t1 bootc/
 podman run -d --name atest bootc-django-t1 /sbin/init
-'''
+```
 
 Then move into the ansible directory and run the site playbook to make all the config changes to prep this as a deployable django environment ready for an application. The selinux failure is being worked on, but should get autorelabeled and fixed by image builder.
 
-'''
+```
 ansible-playbook -c podman -i inventory.containers site.yml
-'''
+```
 
 Once the playbook completes, we have the container configured for our django standards. We can convert that back to an image, then build our QCOW2 image for use.
 
-'''
+```
 podman commit atest localhost:5000/bootc-django-conf
 podman push localhost:5000/bootc-django-conf
 
 sudo podman run --rm -it --privileged --pull=newer --network=host --security-opt label=type:unconfined_t  -v $(pwd)/config.json:/config.json  -v $(pwd)/output:/output  quay.io/centos-bootc/bootc-image-builder:latest --tls-verify=false --type qcow2   --config /config.json localhost:5000/bootc-django-conf
-'''
+```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,47 @@
 # django-demo
 
-Use ansible to create a Django environment on top of a bootc based OS with the correct pacakges to support it
+Use ansible to create a Django 5 environment on top of a bootc based OS with the correct python 3 pacakges to support it
 
 
 The bootc container only contains the OS level mods required for this Django layer to become a functional app environment once configured at run time
 
+** note: the separation of the playbooks is ongoing **
+
 The first set of ansible playbooks contains 'generic' customizations that wire up the django environment according to local standards in prepartion for landing the application later
 
 The second set of ansible playbooks come from a represent run time deployment of the application specific configurations
+
+On the **build host** you'll need the following packages:
+* podman
+* ansible
+* general, podman, and postgresql ansible collections
+
+'''
+sudo dnf install -y podman ansible
+
+ansible-galaxy collection install containers.podman
+ansible-galaxy collection install community.general
+ansible-galaxy collection install community.postgresql
+'''
+
+Once you have the prerequisites, from the root of this repo you can build and run the container
+
+'''
+podman build -t bootc-django-t1 bootc/
+podman run -d --name atest bootc-django-t1 /sbin/init
+'''
+
+Then move into the ansible directory and run the site playbook to make all the config changes to prep this as a deployable django environment ready for an application. The selinux failure is being worked on, but should get autorelabeled and fixed by image builder.
+
+'''
+ansible-playbook -c podman -i inventory.containers site.yml
+'''
+
+Once the playbook completes, we have the container configured for our django standards. We can convert that back to an image, then build our QCOW2 image for use.
+
+'''
+podman commit atest localhost:5000/bootc-django-conf
+podman push localhost:5000/bootc-django-conf
+
+sudo podman run --rm -it --privileged --pull=newer --network=host --security-opt label=type:unconfined_t  -v $(pwd)/config.json:/config.json  -v $(pwd)/output:/output  quay.io/centos-bootc/bootc-image-builder:latest --tls-verify=false --type qcow2   --config /config.json localhost:5000/bootc-django-conf
+'''

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ podman build -t bootc-django-t1 bootc/
 podman run -d --name atest bootc-django-t1 /sbin/init
 ```
 
-Then move into the ansible directory and run the site playbook to make all the config changes to prep this as a deployable django environment ready for an application. The selinux failure is being worked on, but should get autorelabeled and fixed by image builder.
+Run the site playbook to make all the config changes to prep this as a deployable django environment ready for an application. The selinux context setting is being worked on, but should get autorelabeled when built by image builder.
 
 ```
-ansible-playbook -c podman -i inventory.containers site.yml
+ansible-playbook -c podman -i ansible/inventory.containers ansible/site.yml
 ```
 
-Once the playbook completes, we have the container configured for our django standards. We can convert that back to an image, then build our QCOW2 image for use.
+Once the playbook completes, we have the container configured for our django standards. At the moment, this is not working as a local container, only a VM. We can convert that back to an image, then build our QCOW2 image for use.
 
 ```
 podman commit atest localhost:5000/bootc-django-conf
@@ -46,3 +46,5 @@ podman push localhost:5000/bootc-django-conf
 
 sudo podman run --rm -it --privileged --pull=newer --network=host --security-opt label=type:unconfined_t  -v $(pwd)/config.json:/config.json  -v $(pwd)/output:/output  quay.io/centos-bootc/bootc-image-builder:latest --tls-verify=false --type qcow2   --config /config.json localhost:5000/bootc-django-conf
 ```
+
+Get the QCOW image from the output/qcow directory and import into a KVM environment to test.

--- a/README.md
+++ b/README.md
@@ -5,11 +5,7 @@ Use ansible to create a Django 5 environment on top of a bootc based OS with the
 
 The bootc container only contains the OS level mods required for this Django layer to become a functional app environment once configured at run time
 
-**note: the separation of the playbooks is ongoing**
-
-The first set of ansible playbooks contains 'generic' customizations that wire up the django environment according to local standards in prepartion for landing the application later
-
-The second set of ansible playbooks come from a represent run time deployment of the application specific configurations
+The ansible playbooks contain 'generic' customizations that wire up the django environment according to local standards in prepartion for landing an application later
 
 On the **build host** you'll need the following packages:
 * podman

--- a/README.md
+++ b/README.md
@@ -38,12 +38,21 @@ Run the site playbook to make all the config changes to prep this as a deployabl
 ansible-playbook -c podman -i ansible/inventory.containers ansible/site.yml
 ```
 
-Once the playbook completes, we have the container configured for our django standards. At the moment, this is not working as a local container, only a VM. We can convert that back to an image, then build our QCOW2 image for use.
+Once the playbook completes, we have the container configured for our django standards. There aren't any exposed ports in this config, but you can confirm the skeleton is working from a bash shell. We can convert the container back to an image, then build our QCOW2 image for use.
 
 ```
+podman exec -it atest /bin/bash
+bash-5.2# systemctl status nginx postgresql gunicorn.socket
+bash-5.2# curl --unix-socket /run/gunicorn.sock localhost
+
+podman stop atest
 podman commit atest localhost:5000/bootc-django-conf
 podman push localhost:5000/bootc-django-conf
+```
 
+If needed you can create any new configs needed for the qcow before running the build, like an interactive user.
+
+```
 sudo podman run --rm -it --privileged --pull=newer --network=host --security-opt label=type:unconfined_t  -v $(pwd)/config.json:/config.json  -v $(pwd)/output:/output  quay.io/centos-bootc/bootc-image-builder:latest --tls-verify=false --type qcow2   --config /config.json localhost:5000/bootc-django-conf
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,24 @@ podman commit atest localhost:5000/bootc-django-conf
 podman push localhost:5000/bootc-django-conf
 ```
 
-If needed you can create any new configs needed for the qcow before running the build, like an interactive user.
+If needed you can create any new configs needed for the qcow before running the build, like the interactive user.  Create the target directory for the image builder artifacts, then run the image builder container. 
 
 ```
+mkdir output
+
 sudo podman run --rm -it --privileged --pull=newer --network=host --security-opt label=type:unconfined_t  -v $(pwd)/config.json:/config.json  -v $(pwd)/output:/output  quay.io/centos-bootc/bootc-image-builder:latest --tls-verify=false --type qcow2   --config /config.json localhost:5000/bootc-django-conf
 ```
 
 Get the QCOW image from the output/qcow directory and import into a KVM environment to test.
+
+**VM Issues**
+
+The services are not enabled on boot in the QCOW image
+Seboolean needs to be set after first boot to allow communication over the unix socket
+
+```
+setsebool -P daemons_enable_cluster_mode true
+
+systemctl enable --now postgresql nginx.service gunicorn.socket
+
+```

--- a/ansible/django.yml
+++ b/ansible/django.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Provision Django app server
-  hosts: web-hosts
+  hosts: web_hosts
   become: yes
   become_user: root
 

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -1,8 +1,8 @@
 # Example of setting a group of hosts to use Python3
-[web-hosts]
+[web_hosts]
 8beta1.example.com
 
-[db-hosts]
+[db_hosts]
 8beta1.example.com
 
 [rhel8:children]

--- a/ansible/inventory.containers
+++ b/ansible/inventory.containers
@@ -1,0 +1,5 @@
+[web_hosts]
+atest
+
+[db_hosts]
+atest

--- a/ansible/postgres.yml
+++ b/ansible/postgres.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Provision PostgreSQL DB server
-  hosts: db-hosts
+  hosts: db_hosts
   become: yes
   become_user: root
 

--- a/ansible/roles/django/defaults/main.yml
+++ b/ansible/roles/django/defaults/main.yml
@@ -4,6 +4,6 @@ db_host: "{{groups['db-hosts'] | first}}"
 db_name: djangoapp
 db_user: djangouser
 db_password: qwer4321
-project_dir: djangoproject
-django_dir: "/var/srv/{{ project_dir }}"
+project: djangoapp
+django_dir: /var/srv/django_projects
 venv_dir: "{{ django_dir }}/djangovenv"

--- a/ansible/roles/django/defaults/main.yml
+++ b/ansible/roles/django/defaults/main.yml
@@ -4,6 +4,6 @@ db_host: "{{groups['db-hosts'] | first}}"
 db_name: djangoapp
 db_user: djangouser
 db_password: qwer4321
-project_dir: django-project
+project_dir: djangoproject
 django_dir: "/var/srv/{{ project_dir }}"
-venv_dir: "{{ django_dir }}/django-venv"
+venv_dir: "{{ django_dir }}/djangovenv"

--- a/ansible/roles/django/defaults/main.yml
+++ b/ansible/roles/django/defaults/main.yml
@@ -4,6 +4,6 @@ db_host: "{{groups['db-hosts'] | first}}"
 db_name: djangoapp
 db_user: djangouser
 db_password: qwer4321
-project_dir: djangoapp
+project_dir: django-project
 django_dir: "/var/srv/{{ project_dir }}"
-venv_dir: "{{ django_dir }}/django"
+venv_dir: "{{ django_dir }}/django-venv"

--- a/ansible/roles/django/tasks/main.yml
+++ b/ansible/roles/django/tasks/main.yml
@@ -23,8 +23,7 @@
     pip:
       name: 'django, gunicorn, psycopg'
       virtualenv: "{{ venv_dir }}"
-      virtualenv_command: "/usr/bin/python3.11 -m venv"
-      #virtualenv_python: python3.11
+      virtualenv_command: "/usr/bin/python3 -m venv"
 
   - name: Check if Django is initialized.
     stat:

--- a/ansible/roles/django/tasks/main.yml
+++ b/ansible/roles/django/tasks/main.yml
@@ -31,13 +31,13 @@
     register: django_config
 
   - name: Initialize Django
-    command: "{{ venv_dir }}/bin/django-admin startproject {{ project_dir }} {{ django_dir }}"
+    command: "{{ venv_dir }}/bin/django-admin startproject {{ project }} {{ django_dir }}"
     when: not django_config.stat.exists
 
   - name: Update application settings
     template:
       src: settings.py.j2
-      dest: "{{django_dir}}/{{project_dir}}/settings.py"
+      dest: "{{ django_dir }}/{{ project }}/settings.py"
 
   - name: Run DB migrations on the app
     django_manage:

--- a/ansible/roles/django/templates/settings.py.j2
+++ b/ansible/roles/django/templates/settings.py.j2
@@ -79,7 +79,7 @@ DATABASES = {
         'NAME': '{{ db_name }}',
         'USER': '{{ db_user }}',
         'PASSWORD': '{{ db_password }}',
-        'HOST': '{{ db_host }}',
+        'HOST': 'localhost',
     }
 }
 

--- a/ansible/roles/gunicorn/defaults/main.yml
+++ b/ansible/roles/gunicorn/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for gunicorn
 
-project_dir: django-project
-django_dir: "/var/srv/{{ project_dir }}"
-venv_dir: "{{ django_dir }}/django-venv"
+project: djangoapp
+django_dir: /var/srv/django_projects
+venv_dir: "{{ django_dir }}/djangovenv"

--- a/ansible/roles/gunicorn/defaults/main.yml
+++ b/ansible/roles/gunicorn/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for gunicorn
 
-project_dir: djangoapp
+project_dir: django-project
 django_dir: "/var/srv/{{ project_dir }}"
-venv_dir: "{{ django_dir }}/django"
+venv_dir: "{{ django_dir }}/django-venv"

--- a/ansible/roles/gunicorn/templates/nginx-site.j2
+++ b/ansible/roles/gunicorn/templates/nginx-site.j2
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name {{ ansible_fqdn }};
+    server_name localhost};
 
     location = /favicon.ico { access_log off; log_not_found off; }
     location /static/ {

--- a/ansible/roles/gunicorn/templates/service.j2
+++ b/ansible/roles/gunicorn/templates/service.j2
@@ -10,7 +10,7 @@ WorkingDirectory={{ django_dir }}
 ExecStart={{venv_dir}}/bin/gunicorn \
           --access-logfile - \
           --workers 3 \
-          --bind unix:gunicorn.sock {{ project_dir }}.wsgi
+          --bind unix:gunicorn.sock {{ project }}.wsgi
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/gunicorn/templates/socket.j2
+++ b/ansible/roles/gunicorn/templates/socket.j2
@@ -3,6 +3,7 @@ Description=Gunicorn WSGI socket
 
 [Socket]
 ListenStream=/run/gunicorn.sock
+SocketUser=nginx
 
 [Install]
 WantedBy=sockets.target

--- a/ansible/roles/postgres/defaults/main.yml
+++ b/ansible/roles/postgres/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for postgres
 
-db_name: djangoapp
+db_name: p
 db_user: djangouser
 db_password: qwer4321
 db_datapath: /var/lib/pgsql/data

--- a/ansible/roles/postgres/defaults/main.yml
+++ b/ansible/roles/postgres/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for postgres
 
-db_name: p
+db_name: djangoapp
 db_user: djangouser
 db_password: qwer4321
 db_datapath: /var/lib/pgsql/data

--- a/ansible/roles/postgres/tasks/main.yml
+++ b/ansible/roles/postgres/tasks/main.yml
@@ -64,6 +64,15 @@
     priv: ALL
     state: present
 
+- name: Ensure user has create privileges to public schema
+  become: yes
+  become_user: postgres
+  community.postgresql.postgresql_privs:
+    db: "{{ db_name }}"
+    role: "{{ db_user }}"
+    objs: public
+    privs: CREATE
+
 - name: Ensure user does not have unnecessary privileges
   become: yes
   become_user: postgres

--- a/ansible/roles/postgres/tasks/main.yml
+++ b/ansible/roles/postgres/tasks/main.yml
@@ -71,6 +71,7 @@
     db: "{{ db_name }}"
     role: "{{ db_user }}"
     objs: public
+    type: schema
     privs: CREATE
 
 - name: Ensure user does not have unnecessary privileges

--- a/ansible/roles/selinux/defaults/main.yml
+++ b/ansible/roles/selinux/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for selinux
 django_dir: "/var/srv/{{ project_dir }}"
-venv_dir: "{{ django_dir }}/django"
+venv_dir: "{{ django_dir }}/djangovenv"

--- a/ansible/roles/selinux/defaults/main.yml
+++ b/ansible/roles/selinux/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for selinux
-django_dir: "/var/srv/{{ project_dir }}"
+django_dir: /var/srv/django_projects
 venv_dir: "{{ django_dir }}/djangovenv"

--- a/ansible/roles/selinux/files/gunicorn.te
+++ b/ansible/roles/selinux/files/gunicorn.te
@@ -4,3 +4,6 @@ type gunicorn_t;
 type gunicorn_exec_t;
 init_daemon_domain(gunicorn_t, gunicorn_exec_t)
 permissive gunicorn_t;
+
+#============= init_t ==============
+allow init_t gunicorn_exec_t:lnk_file read;

--- a/ansible/roles/selinux/tasks/main.yml
+++ b/ansible/roles/selinux/tasks/main.yml
@@ -43,7 +43,6 @@
     - gunicorn
     - python
     - python3
-    - python3.11
 
 - name: Restart services
   service:

--- a/ansible/roles/selinux/tasks/main.yml
+++ b/ansible/roles/selinux/tasks/main.yml
@@ -44,12 +44,6 @@
   vars:
     ansible_python_interpreter: /usr/bin/python3
 
-- name: Set cluster socket flag and persist it
-  seboolean:
-    name: daemons_enable_cluster_mode
-    state: yes
-    persistent: yes
-
 - name: Restart services
   service:
     name: "{{ item }}"

--- a/ansible/roles/selinux/tasks/main.yml
+++ b/ansible/roles/selinux/tasks/main.yml
@@ -44,12 +44,11 @@
   vars:
     ansible_python_interpreter: /usr/bin/python3
 
-- name: Set flag on and keep it persistent across reboots
+- name: Set cluster socket flag and persist it
   seboolean:
     name: daemons_enable_cluster_mode
     state: yes
     persistent: yes
-
 
 - name: Restart services
   service:

--- a/ansible/roles/selinux/tasks/main.yml
+++ b/ansible/roles/selinux/tasks/main.yml
@@ -44,6 +44,13 @@
   vars:
     ansible_python_interpreter: /usr/bin/python3
 
+- name: Set flag on and keep it persistent across reboots
+  seboolean:
+    name: daemons_enable_cluster_mode
+    state: yes
+    persistent: yes
+
+
 - name: Restart services
   service:
     name: "{{ item }}"

--- a/ansible/roles/selinux/tasks/main.yml
+++ b/ansible/roles/selinux/tasks/main.yml
@@ -28,8 +28,8 @@
 - name: Load policy module
   command: semodule -i /tmp/selinux/gunicorn.pp
 
-- name: Label executables
-  command: chcon -ht gunicorn_exec_t "{{ venv_dir }}/bin/{{ item }}"
+- name: Set the new context for next relabel
+  command: semanage fcontext -a -t gunicorn_exec_t "{{ venv_dir }}/bin/{{ item }}"
   with_items:
     - gunicorn
     - python

--- a/ansible/roles/selinux/tasks/main.yml
+++ b/ansible/roles/selinux/tasks/main.yml
@@ -35,21 +35,20 @@
     - python
     - python3
 
-#- name: Set domains permissive
-#  selinux_permissive:
-#    name: "{{ item }}"
-#    permissive: true
-#  with_items:
-#    - httpd_t
-#  vars:
-#    ansible_python_interpreter: /usr/bin/python3
-#
-#- name: Restart services
-#  service:
-#    name: "{{ item }}"
-#    state: restarted
-#    enabled: yes
-#  with_items:
-#    - gunicorn.socket
-#    - nginx
-#
+- name: Set domains permissive
+  selinux_permissive:
+    name: "{{ item }}"
+    permissive: true
+  with_items:
+    - httpd_t
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+
+- name: Restart services
+  service:
+    name: "{{ item }}"
+    state: restarted
+    enabled: yes
+  with_items:
+    - gunicorn.socket
+    - nginx

--- a/ansible/roles/selinux/tasks/main.yml
+++ b/ansible/roles/selinux/tasks/main.yml
@@ -28,27 +28,28 @@
 - name: Load policy module
   command: semodule -i /tmp/selinux/gunicorn.pp
 
-- name: Set domains permissive
-  selinux_permissive:
-    name: "{{ item }}"
-    permissive: true
-  with_items:
-    - httpd_t
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
-
 - name: Label executables
-  command: chcon -t gunicorn_exec_t "{{ venv_dir }}/bin/{{ item }}"
+  command: chcon -ht gunicorn_exec_t "{{ venv_dir }}/bin/{{ item }}"
   with_items:
     - gunicorn
     - python
     - python3
 
-- name: Restart services
-  service:
-    name: "{{ item }}"
-    state: restarted
-    enabled: yes
-  with_items:
-    - gunicorn.socket
-    - nginx
+#- name: Set domains permissive
+#  selinux_permissive:
+#    name: "{{ item }}"
+#    permissive: true
+#  with_items:
+#    - httpd_t
+#  vars:
+#    ansible_python_interpreter: /usr/bin/python3
+#
+#- name: Restart services
+#  service:
+#    name: "{{ item }}"
+#    state: restarted
+#    enabled: yes
+#  with_items:
+#    - gunicorn.socket
+#    - nginx
+#

--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -10,12 +10,5 @@ RUN dnf -y install vim python3 \
     selinux-policy-devel \
 && rm /var/log/*.log /var/lib/dnf -rf
 
-# Reuse the app user as the ansible user
+# Add the application user here, add another in the config.json
 RUN useradd -ms /bin/bash cloud-user -G wheel
-# ADD core.conf /usr/lib/sysusers.d/
-
-# This seems .. poor
-ADD id_rsa_localvm.pub /var/home/cloud-user/.ssh/
-RUN chmod 700 /var/home/cloud-user/.ssh && \
-chmod 644 /var/home/cloud-user/.ssh/id_rsa_localvm.pub && \
-chown -R cloud-user:cloud-user /var/home/cloud-user

--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -1,4 +1,5 @@
-FROM quay.io/centos-bootc/centos-bootc-dev:stream9
+#FROM quay.io/centos-bootc/centos-bootc-dev:stream9
+FROM quay.io/centos-bootc/fedora-bootc:eln
 
 RUN dnf -y install python3 \
     python3-pip \

--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -1,9 +1,9 @@
 FROM quay.io/centos-bootc/centos-bootc-dev:stream9
 
-RUN dnf -y install python3.11 \
-    python3.11-pip \
-    python3.11-setuptools \
-    python3.11-psycopg2 \
+RUN dnf -y install python3 \
+    python3-pip \
+    python3-setuptools \
+    python3-psycopg2 \
     nginx \
     postgresql-server \
     selinux-policy-devel \

--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -1,7 +1,7 @@
 #FROM quay.io/centos-bootc/centos-bootc-dev:stream9
 FROM quay.io/centos-bootc/fedora-bootc:eln
 
-RUN dnf -y install python3 \
+RUN dnf -y install vim python3 \
     python3-pip \
     python3-setuptools \
     python3-psycopg2 \


### PR DESCRIPTION
Removes the version specification for python, makes some readability changes to the django project, updated selinux policy, and general ansible cleanups

**Remaining Issues**
There are a few 'localhost' hardcoded spots that are workarounds for the current playbooks

The services are not enabled on boot in the QCOW image
Seboolean needs to be set after first boot to allow communication over the unix socket

```
setsebool -P daemons_enable_cluster_mode true

systemctl enable --now postgresql nginx.service gunicorn.socket

```